### PR TITLE
PIZ3-fix-order-price-calculation-bug

### DIFF
--- a/app/controllers/order.py
+++ b/app/controllers/order.py
@@ -12,8 +12,10 @@ class OrderController(BaseController):
 
     @staticmethod
     def calculate_order_price(size_price: float, ingredients: list, beverages: list):
-        price =sum(item.price for item in ingredients + beverages)
-        return round(price, 2)
+        ingredients_price = sum(item.price for item in beverages)
+        beverages_price = sum(item.price for item in ingredients)
+        total_price = size_price + ingredients_price + beverages_price
+        return round(total_price, 2)
 
     @classmethod
     def create(cls, order: dict):

--- a/app/test/controllers/test_order.py
+++ b/app/test/controllers/test_order.py
@@ -1,40 +1,44 @@
 import pytest
-from app.controllers import (IngredientController, OrderController,
+from app.controllers import (IngredientController, BeverageController, OrderController,
                              SizeController)
 from app.controllers.base import BaseController
 from app.test.utils.functions import get_random_choice, shuffle_list
 
 
-def __order(ingredients: list, size: dict, client_data: dict):
+def __order(ingredients: list, size: dict, beverages: list, client_data: dict):
     ingredients = [ingredient.get('_id') for ingredient in ingredients]
     size_id = size.get('_id')
+    beverages = [beverage.get('_id') for beverage in beverages]
     return {
         **client_data,
         'ingredients': ingredients,
-        'size_id': size_id
+        'size_id': size_id,
+        'beverages': beverages 
     }
 
 
 def __create_items(items: list, controller: BaseController):
     created_items = []
-    for ingredient in items:
-        created_item, _ = controller.create(ingredient)
+    for item in items:
+        created_item, _ = controller.create(item)
         created_items.append(created_item)
     return created_items
 
 
-def __create_sizes_and_ingredients(ingredients: list, sizes: list):
+def __create_sizes_ingredients_and_beverages(ingredients: list, sizes: list, beverages: list):
     created_ingredients = __create_items(ingredients, IngredientController)
     created_sizes = __create_items(sizes, SizeController)
-    return created_sizes if len(created_sizes) > 1 else created_sizes.pop(), created_ingredients
+    created_beverages = __create_items(beverages, BeverageController)
+    return created_sizes if len(created_sizes) > 1 else created_sizes.pop(), created_ingredients, created_beverages
 
 
-def test_create(app, ingredients, size, client_data):
-    created_size, created_ingredients = __create_sizes_and_ingredients(ingredients, [size])
-    order = __order(created_ingredients, created_size, client_data)
+def test_create(app, ingredients, size, beverages, client_data):
+    created_size, created_ingredients, created_beverages = __create_sizes_ingredients_and_beverages(ingredients, [size], beverages)
+    order = __order(created_ingredients, created_size, created_beverages, client_data)
     created_order, error = OrderController.create(order)
     size_id = order.pop('size_id', None)
     ingredient_ids = order.pop('ingredients', [])
+    beverage_ids = order.pop('beverages', [])
     pytest.assume(error is None)
     for param, value in order.items():
         pytest.assume(param in created_order)
@@ -42,38 +46,48 @@ def test_create(app, ingredients, size, client_data):
         pytest.assume(created_order['_id'])
         pytest.assume(size_id == created_order['size']['_id'])
 
-        ingredients_in_detail = set(item['ingredient']['_id'] for item in created_order['detail'])
+        ingredients_in_detail = set(item['ingredient']['_id'] for item in created_order['detail'] if item['ingredient'])
         pytest.assume(not ingredients_in_detail.difference(ingredient_ids))
 
+        beverages_in_detail = set(item['beverage']['_id'] for item in created_order['detail'] if item['beverage'])
+        pytest.assume(not beverages_in_detail.difference(beverage_ids))
 
-def test_calculate_order_price(app, ingredients, size, client_data):
-    created_size, created_ingredients = __create_sizes_and_ingredients(ingredients, [size])
-    order = __order(created_ingredients, created_size, client_data)
+
+def test_calculate_order_price(app, ingredients, size, beverages, client_data):
+    created_size, created_ingredients, created_beverages = __create_sizes_ingredients_and_beverages(ingredients, [size], beverages)
+    order = __order(created_ingredients, created_size, created_beverages, client_data)
     created_order, _ = OrderController.create(order)
-    pytest.assume(created_order['total_price'] == round(created_size['price'] + sum(ingredient['price'] for ingredient in created_ingredients), 2))
+    ingredients_price = sum(ingredient['price'] for ingredient in created_ingredients)
+    beverages_price = sum(beverage['price'] for beverage in created_beverages)
+    expected_total_price = round(created_size['price'] + ingredients_price + beverages_price, 2)
+    pytest.assume(created_order['total_price'] == expected_total_price)
 
 
-def test_get_by_id(app, ingredients, size, client_data):
-    created_size, created_ingredients = __create_sizes_and_ingredients(ingredients, [size])
-    order = __order(created_ingredients, created_size, client_data)
+def test_get_by_id(app, ingredients, size, beverages, client_data):
+    created_size, created_ingredients, created_beverages = __create_sizes_ingredients_and_beverages(ingredients, [size], beverages)
+    order = __order(created_ingredients, created_size, created_beverages, client_data)
     created_order, _ = OrderController.create(order)
     order_from_db, error = OrderController.get_by_id(created_order['_id'])
     size_id = order.pop('size_id', None)
     ingredient_ids = order.pop('ingredients', [])
+    beverage_ids = order.pop('beverages', [])
     pytest.assume(error is None)
     for param, value in created_order.items():
         pytest.assume(order_from_db[param] == value)
         pytest.assume(size_id == created_order['size']['_id'])
 
-        ingredients_in_detail = set(item['ingredient']['_id'] for item in created_order['detail'])
+        ingredients_in_detail = set(item['ingredient']['_id'] for item in created_order['detail'] if item['ingredient'])
         pytest.assume(not ingredients_in_detail.difference(ingredient_ids))
 
+        beverages_in_detail = set(item['beverage']['_id'] for item in created_order['detail']  if item['beverage'])
+        pytest.assume(not beverages_in_detail.difference(beverage_ids))
 
-def test_get_all(app, ingredients, sizes, client_data):
-    created_sizes, created_ingredients = __create_sizes_and_ingredients(ingredients, sizes)
+
+def test_get_all(app, ingredients, sizes, beverages, client_data):
+    created_sizes, created_ingredients, created_beverages = __create_sizes_ingredients_and_beverages(ingredients, sizes, beverages)
     created_orders = []
     for _ in range(5):
-        order = __order(shuffle_list(created_ingredients)[:3], get_random_choice(created_sizes), client_data)
+        order = __order(shuffle_list(created_ingredients)[:3], get_random_choice(created_sizes), shuffle_list(created_beverages)[:3], client_data)
         created_order, _ = OrderController.create(order)
         created_orders.append(created_order)
 

--- a/app/test/fixtures/order.py
+++ b/app/test/fixtures/order.py
@@ -24,26 +24,30 @@ def client_data():
 
 
 @pytest.fixture
-def order(create_ingredients, create_size, client_data) -> dict:
+def order(create_ingredients, create_size, client_data, create_beverages) -> dict:
     ingredients = [ingredient.get('_id') for ingredient in create_ingredients]
     size_id = create_size.get('_id')
+    beverages = [beverage.get('_id') for beverage in create_beverages]
     return {
         **client_data_mock(),
         'ingredients': ingredients,
-        'size_id': size_id
+        'size_id': size_id,
+        'beverages': beverages
     }
 
 
 @pytest.fixture
-def create_orders(client, order_uri, create_ingredients, create_sizes) -> list:
+def create_orders(client, order_uri, create_ingredients, create_sizes, create_beverages) -> list:
     ingredients = [ingredient.get('_id') for ingredient in create_ingredients]
     sizes = [size.get('_id') for size in create_sizes]
+    beverages = [beverage.get('_id') for beverage in create_beverages]
     orders = []
     for _ in range(10):
         new_order = client.post(order_uri, json={
             **client_data_mock(),
             'ingredients': shuffle_list(ingredients)[:5],
-            'size_id': shuffle_list(sizes)[0]
+            'size_id': shuffle_list(sizes)[0],
+            'beverages': shuffle_list(beverages)[:5]
         })
         orders.append(new_order)
     return orders


### PR DESCRIPTION
**Ticket link:**
[PIZ3](https://trello.com/c/f1Vc2qmu)

**Description:**
The total price calculation for orders is incorrect. Currently, the system doesn’t add the pizza size price, which leads to discrepancies in the final amount.

**Tests:**
![image](https://github.com/user-attachments/assets/68ef15f2-bef2-41f0-a14b-3aa09e4b0efc)

**Screenshot/Video:**
- Order and order detail displaying correct price calculation:
![Screenshot from 2024-08-14 13-16-16](https://github.com/user-attachments/assets/59a23cc8-4e86-462d-a399-ce0e8ff9edb1)
![Screenshot from 2024-08-14 13-16-40](https://github.com/user-attachments/assets/4caf3974-7342-4252-9420-cd84316b43ea)