### PR TITLE
PIZ8-increase-test-coverage

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -1,12 +1,9 @@
-name: CI Workflow
+name: CI test workflow
 
 on:
-    push:
-        branches:
-            - '*'
     pull_request:
         branches:
-            - '*'
+            - "main"
 
 jobs:
     build:
@@ -43,13 +40,5 @@ jobs:
               uses: coroo/pytest-coverage-commentator@v1.0.2
               with:
                 pytest-coverage: coverage.txt
-            
-            - name: Run formatter
-              run: |
-                  source venv/bin/activate
-                  make run-formater
-
-            - name: Run linter
-              run: |
-                source venv/bin/activate
-                make run-lint
+              env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ run-tests:
 	python3 manage.py test
 
 run-coverage:
-	python3 -m pytest -v --cov=app --cov-report=term-missing
+	python3 -m pytest -v --cov=app --cov-report=term-missing > coverage.txt
 
 run-formater:
 	autopep8 --max-line-length 110 --experimental -i -r app/

--- a/app/test/controllers/test_order/test_order.py
+++ b/app/test/controllers/test_order/test_order.py
@@ -63,6 +63,11 @@ def test_create(app, ingredients, size, beverages, client_data):
         pytest.assume(not beverages_in_detail.difference(beverage_ids))
 
 
+def test_create_with_invalid_payload(app, client_data):
+    order, error = OrderController.create(client_data)
+    pytest.assume(order == "Invalid order payload")
+
+
 def test_get_by_id(app, ingredients, size, beverages, client_data):
     created_size, created_ingredients, created_beverages = __create_sizes_ingredients_and_beverages(
         ingredients,

--- a/app/test/fixtures/order.py
+++ b/app/test/fixtures/order.py
@@ -2,8 +2,8 @@ import pytest
 
 from app.controllers.order.order_builder import OrderBuilder
 
-from ..utils.functions import (get_random_sequence, get_random_string,
-                               shuffle_list)
+from ..utils.functions import (get_random_phone, get_random_sequence,
+                               get_random_string, shuffle_list)
 
 
 def client_data_mock() -> dict:
@@ -11,7 +11,7 @@ def client_data_mock() -> dict:
         'client_address': get_random_string(),
         'client_dni': get_random_sequence(),
         'client_name': get_random_string(),
-        'client_phone': get_random_sequence()
+        'client_phone': get_random_phone()
     }
 
 
@@ -48,16 +48,17 @@ def mock_order_builder(create_size, create_ingredients, create_beverages):
 
 
 @pytest.fixture
-def order(create_ingredients, create_size, create_beverages, client_data) -> dict:
+def create_order(client, order_uri, create_ingredients, create_size, create_beverages) -> dict:
     ingredients = [ingredient.get('_id') for ingredient in create_ingredients]
-    size_id = create_size.get('_id')
+    size_id = create_size.json.get('_id')
     beverages = [beverage.get('_id') for beverage in create_beverages]
-    return {
+    order = client.post(order_uri, json={
         **client_data_mock(),
         'ingredients': ingredients,
         'size_id': size_id,
         'beverages': beverages
-    }
+    })
+    return order
 
 
 @pytest.fixture

--- a/app/test/services/test_order.py
+++ b/app/test/services/test_order.py
@@ -1,0 +1,34 @@
+import pytest
+
+
+def test_create_order_service(create_order):
+    order = create_order.json
+    print(order)
+    pytest.assume(create_order.status.startswith('200'))
+    pytest.assume(order['_id'])
+    pytest.assume(order['client_address'])
+    pytest.assume(order['client_dni'])
+    pytest.assume(order['client_name'])
+    pytest.assume(order['client_phone'])
+    pytest.assume(order['date'])
+    pytest.assume(order['detail'])
+    pytest.assume(order['size'])
+    pytest.assume(order['total_price'])
+
+
+def test_get_order_by_id_service(client, create_order, order_uri):
+    current_order = create_order.json
+    response = client.get(f'{order_uri}id/{current_order["_id"]}')
+    pytest.assume(response.status.startswith('200'))
+    returned_order = response.json
+    for param, value in current_order.items():
+        pytest.assume(returned_order[param] == value)
+
+
+def test_get_orders_service(client, create_orders, order_uri):
+    response = client.get(order_uri)
+    pytest.assume(response.status.startswith('200'))
+    returned_orders = {order['_id']: order for order in response.json}
+    print(returned_orders)
+    for order in create_orders:
+        pytest.assume(order.json['_id'] in returned_orders)

--- a/app/test/services/test_size.py
+++ b/app/test/services/test_size.py
@@ -1,7 +1,36 @@
 import pytest
 
+from app.test.utils.functions import get_random_price, get_random_string
 
-def test_get_size_service(client, create_sizes, size_uri):
+
+def test_create_size_service(create_size):
+    size = create_size.json
+    pytest.assume(create_size.status.startswith('200'))
+    pytest.assume(size['_id'])
+    pytest.assume(size['name'])
+    pytest.assume(size['price'])
+
+
+def test_update_size_service(client, create_size, size_uri):
+    current_size = create_size.json
+    update_data = {**current_size, 'name': get_random_string(), 'price': get_random_price(1, 5)}
+    response = client.put(size_uri, json=update_data)
+    pytest.assume(response.status.startswith('200'))
+    updated_size = response.json
+    for param, value in update_data.items():
+        pytest.assume(updated_size[param] == value)
+
+
+def test_get_size_by_id_service(client, create_size, size_uri):
+    current_size = create_size.json
+    response = client.get(f'{size_uri}id/{current_size["_id"]}')
+    pytest.assume(response.status.startswith('200'))
+    returned_size = response.json
+    for param, value in current_size.items():
+        pytest.assume(returned_size[param] == value)
+
+
+def test_get_sizes_service(client, create_sizes, size_uri):
     response = client.get(size_uri)
     pytest.assume(response.status.startswith('200'))
     returned_sizes = {size['_id']: size for size in response.json}


### PR DESCRIPTION
**Ticket link:**
[PIZ8](https://trello.com/c/zXVArj9O)

**Description:**
Currently, the project only has tests for the ingredient service.

Requirements
Add the missing test cases for the size, and order service to increase test coverage.
Create a CI job with GitHub actions to run the tests and coverage when a PR is created.

**Tests:**
![image](https://github.com/user-attachments/assets/d8087c9c-a0dc-4095-a76e-9c565ab67fd9)

**Screenshot/Video:**
![image](https://github.com/user-attachments/assets/e9d70720-8b6f-45a3-9b0b-722e11d8efb4)
